### PR TITLE
Small but vital changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ When you restart/run `apsd` afterwards (`kill` or `launchctl`), after a few fail
 ### Extract and copy device certificate
 #### Extract iOS Certificates
 
-First, download the [nimble](http://xs1.iphwn.org/releases/PushFix.zip) tool, extract `PushFix.zip` and place `nimble` into `setup/ios`. The following script will copy the tool to your iOS device, run it and copy the extracted certificates back to your computer. It assumes you have **SSH** running on your device. I recommend setting up key-based authentication, otherwise you will be typing your password a few times.
+First, download the [nimble](https://web.archive.org/web/20140215110845if_/http://xs1.iphwn.org/releases/PushFix.zip) tool, extract `PushFix.zip` and place `nimble` into `setup/ios`. The following script will copy the tool to your iOS device, run it and copy the extracted certificates back to your computer. It assumes you have **SSH** running on your device. I recommend setting up key-based authentication, otherwise you will be typing your password a few times.
 
 Make sure you are in the pushproxy root directory, otherwise the script will fail.
 

--- a/setup/genpki.sh
+++ b/setup/genpki.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+openssl genrsa -out ca.key 2048
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 1024 -out ca.crt -subj '/C=US/ST=CA/O=Organization/'
+
+genkey() {
+    OUTPEM="${2:-$1.pem}"
+    openssl genrsa -out "$OUTPEM" 2048
+    openssl req -new -sha256 -key "$OUTPEM" -subj "/C=US/ST=CA/O=Organization/CN=${3:-$1}" -out "$1.csr"
+    openssl x509 -req -in "$1.csr" -CA ca.crt -CAkey ca.key -CAcreateserial -days 500 -sha256 >> "$OUTPEM"
+    rm "$1.csr"
+}
+
+genkey init-p01st.push.apple.com
+mkdir -p certs/courier.push.apple.com/
+genkey courier.push.apple.com certs/courier.push.apple.com/server.pem *.push.apple.com

--- a/src/pushserver.py
+++ b/src/pushserver.py
@@ -30,14 +30,10 @@ DISPATCH_HANDLERS = [LoggingHandler(),
 
 
 APPLE_PUSH_IPS = (
-        '17.172.232.218',
-        '17.172.232.59',
-        '17.172.232.134',
-        '17.172.232.135',
-        '17.172.232.145',
-        '17.172.232.216',
-        '17.172.232.142',
-        '17.172.232.212')
+        '1-courier.push.apple.com',
+        '2-courier.push.apple.com',
+        '3-courier.push.apple.com',
+        '4-courier.push.apple.com')
 
 factory = InterceptServerFactory(
     hosts=APPLE_PUSH_IPS,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-Twisted>=11.0.0
+Twisted==12.0.0
 biplist==0.4
-pyOpenSSL==0.14
+pyOpenSSL


### PR DESCRIPTION
In order to MITM traffic from an iPad 2 running iOS 5.1.1, I had to make some slight changes - here they are. I suspect this will prevent pushproxy from sniffing traffic on the device it's running on because with these changes, pushproxy requires valid DNS lookups, but these lookups may be mitm'd by pushproxy itself, causing a recursive MITM loop.